### PR TITLE
Added option for passing hls.js config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,21 @@ Include in your app javascript (e.g. src/App.js)
 import 'hls-video-element';
 ```
 This will register the custom elements with the browser so they can be used as HTML.
+
+## Configuring HLS.js
+Under the hood we are using [HLS.js](https://hls-js.netlify.app/demo/) to parse and play back the HLS manifest. You can pass HLS.js config parameters by setting the `hlsjsConfig` property on the elememnt object. For example:
+
+```html
+<hls-video
+  controls
+  src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe.m3u8">
+  <track label="thumbnails" id="customTrack" default kind="metadata" src="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/storyboard.vtt"></track>
+</hls-video>
+
+<script>
+  const video = document.querySelector('hls-video');
+  video.hlsjsConfig = { debug: true };
+</script>
+```
+
+[See the config parameters.](https://github.com/video-dev/hls.js/blob/master/docs/API.md#fine-tuning)

--- a/README.md
+++ b/README.md
@@ -57,13 +57,19 @@ Under the hood we are using [HLS.js](https://hls-js.netlify.app/demo/) to parse 
 ```html
 <hls-video
   controls
-  src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe.m3u8">
-  <track label="thumbnails" id="customTrack" default kind="metadata" src="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/storyboard.vtt"></track>
+  src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe.m3u8"
+>
 </hls-video>
 
 <script>
-  const video = document.querySelector('hls-video');
-  video.hlsjsConfig = { debug: true };
+  customElements.whenDefined('hls-video').then(()=>{
+    const hlsVideo = document.querySelector('hls-video');
+    // Update the config object as desired
+    hlsVideo.hlsjsConfig = {
+      debug: true
+    };
+    hlsVideo.load();
+  });
 </script>
 ```
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,8 @@
 
     <hls-video
       controls
-      src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe.m3u8">
+      src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe.m3u8"
+    >
       <track label="thumbnails" id="customTrack" default kind="metadata" src="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/storyboard.vtt"></track>
     </hls-video>
 

--- a/index.js
+++ b/index.js
@@ -25,15 +25,20 @@ class HLSVideoElement extends CustomVideoElement {
 
   load() {
     if (Hls.isSupported()) {
-      var hls = new Hls({
+      let config = Object.assign({
         // Kind of like preload metadata, but causes spinner.
         // autoStartLoad: false,
-      });
+      }, this.hlsjsConfig);
+
+      var hls = new Hls(config);
 
       hls.loadSource(this.src);
       hls.attachMedia(this.nativeEl);
     } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
       this.nativeEl.src = this.src;
+      this.nativeEl.load();
+    } else {
+      console.error('<hls-video>: HLS is not supported.');
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -24,13 +24,15 @@ class HLSVideoElement extends CustomVideoElement {
   }
 
   load() {
+    if (this._hlsjs) this._hlsjs.destroy();
+
     if (Hls.isSupported()) {
       let config = Object.assign({
         // Kind of like preload metadata, but causes spinner.
         // autoStartLoad: false,
       }, this.hlsjsConfig);
 
-      var hls = new Hls(config);
+      const hls = this._hlsjs = new Hls(config);
 
       hls.loadSource(this.src);
       hls.attachMedia(this.nativeEl);


### PR DESCRIPTION
Addresses #3 

With this change you can now set `element.hlsjsConfig`, and that object will be used when the source is loaded.

For example.
```html
<hls-video
  controls
  src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe.m3u8"
>
  <track label="thumbnails" id="customTrack" default kind="metadata" src="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/storyboard.vtt"></track>
</hls-video>

<script>
  customElements.whenDefined('hls-video').then(()=>{
    const hlsVideo = document.querySelector('hls-video');
    // Update the config object as desired
    hlsVideo.hlsjsConfig = {
      debug: true
    };
    hlsVideo.load();
  });
</script>
```