### PR TITLE
Test this.nativeEl for canPlayType and not video which is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ class HLSVideoElement extends CustomVideoElement {
 
       this.hls = new Hls({ autoStartLoad: true });
       this.hls.attachMedia(this.nativeEl);
-      this.hls.on(Hls.Events.MEDIA_ATTACHED, () => this.hls.loadSource(this.src));      
+      this.hls.loadSource(this.src);    
       this.hls.on(Hls.Events.FRAG_LOADED, () => {
         if(laodedFragmentCount === 0) {
           this.hls.stopLoad();

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ class HLSVideoElement extends CustomVideoElement {
 
       hls.loadSource(this.src);
       hls.attachMedia(this.nativeEl);
-    } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+    } else if (this.nativeEl.canPlayType('application/vnd.apple.mpegurl')) {
       this.nativeEl.src = this.src;
     }
   }

--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ class HLSVideoElement extends CustomVideoElement {
         // autoStartLoad: false,
       });
 
-      hls.loadSource(this.src);
       hls.attachMedia(this.nativeEl);
+      hls.on(Hls.Events.MEDIA_ATTACHED, () => hls.loadSource(this.src));
     } else if (this.nativeEl.canPlayType('application/vnd.apple.mpegurl')) {
       this.nativeEl.src = this.src;
     }

--- a/index.js
+++ b/index.js
@@ -23,15 +23,22 @@ class HLSVideoElement extends CustomVideoElement {
     }
   }
 
+  // To be compatible with chrome-media and not load continously at start fragments,
+  // we startload and listen for the first fragment to be loaded
+  // then we stop load
   load() {
     if (Hls.isSupported()) {
-      this.hls = new Hls({ autoStartLoad: false });
+      let laodedFragmentCount = 0
 
-      // this.hls.loadSource(this.src);
-      // this.hls.attachMedia(this.nativeEl);
+      this.hls = new Hls({ autoStartLoad: true });
       this.hls.attachMedia(this.nativeEl);
-      this.hls.on(Hls.Events.MEDIA_ATTACHED, () => this.hls.loadSource(this.src));
-
+      this.hls.on(Hls.Events.MEDIA_ATTACHED, () => this.hls.loadSource(this.src));      
+      this.hls.on(Hls.Events.FRAG_LOADED, () => {
+        if(laodedFragmentCount === 0) {
+          this.hls.stopLoad();
+          laodedFragmentCount++;
+        };
+      });
     } else if (this.nativeEl.canPlayType('application/vnd.apple.mpegurl')) {
       this.nativeEl.src = this.src;
     }

--- a/old.js
+++ b/old.js
@@ -1,3 +1,4 @@
+
 // Web Components: Extending Native Elements, A working example
 
 import CustomVideoElement from 'custom-video-element';
@@ -25,13 +26,43 @@ class HLSVideoElement extends CustomVideoElement {
 
   load() {
     if (Hls.isSupported()) {
-      this.hls = new Hls({ autoStartLoad: false });
+      const hlsConfig = {
+        debug: true,
+        autoStartLoad: false
+      }
 
-      // this.hls.loadSource(this.src);
+      // We attach hls to this to use it externally
+      this.hls = new Hls(hlsConfig);
+
+      // We first attachMedia to the native video element
+      // https://github.com/video-dev/hls.js/blob/master/docs/API.md#third-step-load-a-manifest
       // this.hls.attachMedia(this.nativeEl);
-      this.hls.attachMedia(this.nativeEl);
-      this.hls.on(Hls.Events.MEDIA_ATTACHED, () => this.hls.loadSource(this.src));
 
+      // // Then we loadSource when MEDIA_ATTACHED event is fired
+      // this.hls.on(Hls.Events.MEDIA_ATTACHED, () => this.hls.loadSource(this.src));
+
+      // // We manage errors because it could happen under certains conditions
+      // // https://github.com/video-dev/hls.js/blob/master/docs/API.md#fifth-step-error-handling
+      // this.hls.on(Hls.Events.ERROR, (event, data) => {
+      //   if (data.fatal) {
+      //     switch (data.type) {
+      //       case Hls.ErrorTypes.NETWORK_ERROR:
+      //         console.log('fatal network error encountered, try to recover');
+      //         this.hls.startLoad();
+      //         break;
+      //       case Hls.ErrorTypes.MEDIA_ERROR:
+      //         console.log('fatal media error encountered, try to recover');
+      //         this.hls.recoverMediaError();
+      //         break;
+      //       default:
+      //         // cannot recover
+      //         this.hls.destroy();
+      //         break;
+      //     }
+      //   }
+      // });
+      this.hls.loadSource(this.src);
+      this.hls.attachMedia(this.nativeEl);
     } else if (this.nativeEl.canPlayType('application/vnd.apple.mpegurl')) {
       this.nativeEl.src = this.src;
     }
@@ -57,6 +88,13 @@ class HLSVideoElement extends CustomVideoElement {
     // if (this.preload === 'auto') {
     //   this.load();
     // }
+  }
+
+  // We destroy the hls if we use it
+  disconnectedCallback() {
+    if (this.hls) {
+      this.hls.destroy()
+    }
   }
 }
 


### PR DESCRIPTION
Hi,

When I test https://github.com/muxinc/hls-video-element/blob/master/index.html on safari, it's not working. 
So I correct the bug.

Secondly, use a correct order for loading the media as the hls.js says (https://github.com/video-dev/hls.js/blob/master/docs/API.md#third-step-load-a-manifest):
1) attachMedia to the native video element
2) then loadSource when MEDIA_ATTACHED's event is fired

Best regards,