### PR TITLE
Make the live duration Inifinity

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,17 @@
   </head>
   <body>
 
+    <h2>On-demand</h2>
     <hls-video
       controls
       src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe.m3u8">
       <track label="thumbnails" id="customTrack" default kind="metadata" src="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/storyboard.vtt"></track>
+    </hls-video>
+
+    <h2>Live</h2>
+    <hls-video
+      controls
+      src="http://stream.mux.com/v69RSHhFelSm4701snP22dYz2jICy4E4FUyk02rW4gxRM">
     </hls-video>
 
     <p><a href="https://github.com/muxinc/hls-video-element">github.com/muxinc/hls-video-element</a></p>

--- a/index.js
+++ b/index.js
@@ -28,6 +28,10 @@ class HLSVideoElement extends CustomVideoElement {
       var hls = new Hls({
         // Kind of like preload metadata, but causes spinner.
         // autoStartLoad: false,
+
+        // Mimic the media element with an Infinity duration
+        // for live streams
+        liveDurationInfinity: true
       });
 
       hls.loadSource(this.src);


### PR DESCRIPTION
For a live stream (non-Event/DVR) the media element's duration will be Infinity, however this isn't the default when using HLS.js. Setting [liveDurationInfinity](https://github.com/video-dev/hls.js/blob/master/docs/API.md#livedurationinfinity) to `true` fixes that.