### PR TITLE
Let Hls.js initialize then wait 1 tick for other attributes.

### DIFF
--- a/hls-video-element.js
+++ b/hls-video-element.js
@@ -28,8 +28,7 @@ class HLSVideoElement extends CustomVideoElement {
       return;
     }
 
-    // Wait 1 tick to allow other attributes to be set.
-    await Promise.resolve();
+  
 
     if (Hls.isSupported()) {
 
@@ -38,8 +37,10 @@ class HLSVideoElement extends CustomVideoElement {
         liveDurationInfinity: true
       });
 
-      // Set up preload
+      // Wait 1 tick to allow other attributes to be set.
+      await Promise.resolve();
 
+      // Set up preload
       switch (this.nativeEl.preload) {
         case 'none': {
           // when preload is none, load the source on first play


### PR DESCRIPTION
Waiting for a tick before we initialize hls.js means the following code will not work as `api` will be null until the tick after.

```js
const videoElement = document.querySelector('hls-video');
videoElement.api.on(Hls.Events.MEDIA_ATTACHED, () => {
  console.log('attached');
});
```

