### PR TITLE
Reexport Hls.js

### DIFF
--- a/hls-video-element.d.ts
+++ b/hls-video-element.d.ts
@@ -30,3 +30,5 @@ declare class HLSVideoElement extends CustomVideoElement {
 }
 
 export default HLSVideoElement;
+
+export { Hls };

--- a/hls-video-element.js
+++ b/hls-video-element.js
@@ -91,3 +91,5 @@ if (globalThis.customElements && !globalThis.customElements.get('hls-video')) {
 }
 
 export default HLSVideoElement;
+
+export { Hls }

--- a/hls-video-element.js
+++ b/hls-video-element.js
@@ -93,4 +93,4 @@ if (globalThis.customElements && !globalThis.customElements.get('hls-video')) {
 
 export default HLSVideoElement;
 
-export { Hls }
+export { Hls };


### PR DESCRIPTION
This allows consuming apps to use the underlying library without needing to add hls.js to their own dependancies, avoids version mismatches etc.

an example where you want to use `Hls.Events`

```typescript
import HLSVideoElement, { Hls } from 'hls-video-element';

const videoElement: HLSVideoElement = document.querySelector('hls-video');
const videoElement.api?.on(Hls.Events.MEDIA_ATTACHED, () => {
  console.log('attached');
});
```

~~If #33 is merged before this, I'll add `export { Hls };` to the types before this is merged.~~